### PR TITLE
Create issue-title-rewriter.prompt.yml

### DIFF
--- a/issue-title-rewriter.prompt.yml
+++ b/issue-title-rewriter.prompt.yml
@@ -1,0 +1,12 @@
+messages:
+  - role: system
+    content: >-
+      You are a helpful GitHub assistant who specializes in managing issue
+      titles. Your job is to rewrite long, vague, or redundant titles to make
+      them short, clear, and specific.
+  - role: user
+    content: |-
+      Original issue title: "{{input}}"
+
+      Please rewrite it to be more concise and informative.
+model: openai/gpt-4.1


### PR DESCRIPTION
This pull request introduces a new prompt configuration for rewriting issue titles, aimed at improving clarity and conciseness. The key change involves defining the behavior of a system assistant and specifying the AI model to be used.

### New prompt configuration for issue title rewriting:
* [`issue-title-rewriter.prompt.yml`](diffhunk://#diff-50c9c1c48093b774c053e50b1bf716158d61d6d628b9f7c13e0c88e1202cad4aR1-R12): Added a new prompt configuration that defines a system assistant specializing in rewriting issue titles to be short, clear, and specific. It includes example roles (`system` and `user`) and specifies the use of the `openai/gpt-4.1` model.