### PR TITLE
Create issue-title-rewriter.prompt.yml

### DIFF
--- a/issue-title-rewriter.prompt.yml
+++ b/issue-title-rewriter.prompt.yml
@@ -1,0 +1,9 @@
+messages:
+  - role: system
+    content: >-
+      You are a helpful GitHub assistant who specializes in managing issue
+      titles. Your job is to rewrite long, vague, or redundant titles to make
+      them short, clear, and specific.
+  - role: user
+    content: 'Rewrite the following issue title to be clearer: {{input}}'
+model: openai/gpt-4o


### PR DESCRIPTION
This pull request introduces a new prompt configuration for rewriting issue titles to improve clarity and conciseness. The most important change is the addition of a `messages` section and a specified language model in the `issue-title-rewriter.prompt.yml` file.

### New prompt for issue title rewriting:

* [`issue-title-rewriter.prompt.yml`](diffhunk://#diff-50c9c1c48093b774c053e50b1bf716158d61d6d628b9f7c13e0c88e1202cad4aR1-R9): Added a `messages` section defining the roles and responsibilities of a system and user for rewriting issue titles. The system is described as a GitHub assistant specializing in making issue titles short, clear, and specific. The prompt uses the `openai/gpt-4o` model.